### PR TITLE
Fix corrupted eeprom read

### DIFF
--- a/stk500boot.c
+++ b/stk500boot.c
@@ -1444,10 +1444,13 @@ int main(void)
 						else
 						{
 							/* Read EEPROM */
+							uint16_t ii = address >> 1;
 							do {
-								EEARL	=	address;			// Setup EEPROM address
-								EEARH	=	((address >> 8));
-								address++;					// Select next EEPROM byte
+								EEARL	=	ii;			// Setup EEPROM address
+								EEARH	=	((ii >> 8));
+								address += 2; // Select next EEPROM byte
+								ii++;
+
 								EECR	|=	(1<<EERE);			// Read EEPROM
 								*p++	=	EEDR;				// Send EEPROM data
 								size--;


### PR DESCRIPTION
These are the exact changes that can be found here: https://github.com/arduino/ArduinoCore-avr/pull/24
Fixes an issue where the EEPROM position was doubled and resulted in corrupted data. Now we divide the address by 2 and now it is read correctly. More about this issue can be read in the PR linked.