### PR TITLE
Inform the firmware which uart is used

### DIFF
--- a/stk500boot.c
+++ b/stk500boot.c
@@ -970,6 +970,20 @@ int main(void)
 
 	if (boot_state==1)
 	{
+		// Signal to the firmware the uart that is used
+#ifdef DUALSERIAL
+		if (selectedSerial == 0)
+		{
+			GPIOR0 = 0x01; //primary uart
+		}
+		else
+		{
+			GPIOR0 = 0x02; //secondary uart
+		}
+#else //DUALSERIAL
+		GPIOR0 = 0x01; //primary uart
+#endif //DUALSERIAL
+		
 		//*	main loop
 		while (!isLeave)
 		{
@@ -1500,6 +1514,11 @@ int main(void)
 		#endif
 
 		}
+	}
+	else if (boot_state == 2)
+	{
+		//no character received. Signal timeout.
+		GPIOR0 = 0xFF;
 	}
 
 

--- a/stk500boot.c
+++ b/stk500boot.c
@@ -974,14 +974,14 @@ int main(void)
 #ifdef DUALSERIAL
 		if (selectedSerial == 0)
 		{
-			GPIOR0 = 0x01; //primary uart
+			GPIOR0 = 0x00; //primary uart
 		}
 		else
 		{
-			GPIOR0 = 0x02; //secondary uart
+			GPIOR0 = 0x01; //secondary uart
 		}
 #else //DUALSERIAL
-		GPIOR0 = 0x01; //primary uart
+		GPIOR0 = 0x00; //primary uart
 #endif //DUALSERIAL
 		
 		//*	main loop
@@ -1518,7 +1518,7 @@ int main(void)
 	else if (boot_state == 2)
 	{
 		//no character received. Signal timeout.
-		GPIOR0 = 0xFF;
+		GPIOR0 = 0x00;
 	}
 
 


### PR DESCRIPTION
This should make flashing a full firmware via the secondary uart possible.
Used in combination with https://github.com/prusa3d/Prusa-Firmware/pull/3439