### PR TITLE
Fix DDRAM address for upgrading message

### DIFF
--- a/stk500boot.c
+++ b/stk500boot.c
@@ -1074,7 +1074,7 @@ int main(void)
 			    lcd_clrscr();
                 lcd_goto(20);
                 lcd_puts(" Do not disconnect!");
-                lcd_goto(45);
+                lcd_goto(64);
                 lcd_puts(" Upgrading firmware");
                 messageShown = 1;
             }


### PR DESCRIPTION
Starting with the A008 LCD revision, the "Upgrading firmware, Do not disconnect" screen is corrupted. This was because one of the messages was being written outside the screen area (and _somehow_ it was working). This PR fixes that problem, so the rendering should be functional on all screens